### PR TITLE
Fix error casting to AbstractEvent

### DIFF
--- a/src/main/java/com/meronat/latch/events/LockCreateEvent.java
+++ b/src/main/java/com/meronat/latch/events/LockCreateEvent.java
@@ -30,8 +30,9 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.Event;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.impl.AbstractEvent;
 
-public class LockCreateEvent implements Event, Cancellable  {
+public class LockCreateEvent extends AbstractEvent implements Cancellable  {
 
     private final Cause cause;
     private final Player creator;


### PR DESCRIPTION
[Just noticed your issue on SpongeCommon](https://github.com/SpongePowered/SpongeCommon/issues/1107), this should fix your problem. 

Note that `AbstractEvent` should be used on event implementations, like you have here. If you create an _interface_ for an event, that's when you use the Event interface.

Hope this helps!