### PR TITLE
Adding a last accessed time to locks

### DIFF
--- a/src/main/java/com/meronat/latch/Configuration.java
+++ b/src/main/java/com/meronat/latch/Configuration.java
@@ -171,6 +171,14 @@ class Configuration {
             this.rootNode.getNode("remove_bypass_on_logout").setValue(true);
         }
 
+        if (this.rootNode.getNode("clean_old_locks").isVirtual()) {
+            this.rootNode.getNode("clean_old_locks").setValue(false);
+        }
+
+        if (this.rootNode.getNode("clean_old_locks_interval").isVirtual()) {
+            this.rootNode.getNode("clean_old_locks_interval").setValue(2);
+        }
+
     }
 
     private void saveConfig() {

--- a/src/main/java/com/meronat/latch/Configuration.java
+++ b/src/main/java/com/meronat/latch/Configuration.java
@@ -179,6 +179,10 @@ class Configuration {
             this.rootNode.getNode("clean_old_locks_interval").setValue(2);
         }
 
+        if (this.rootNode.getNode("clean_locks_older_than").isVirtual()) {
+            this.rootNode.getNode("clean_locks_older_than").setValue(40);
+        }
+
     }
 
     private void saveConfig() {

--- a/src/main/java/com/meronat/latch/Latch.java
+++ b/src/main/java/com/meronat/latch/Latch.java
@@ -160,10 +160,10 @@ public class Latch {
         if (getConfig().getNode("clean_old_locks").getBoolean(false)) {
             Task.builder()
                     .name("clean-old-locks")
-                    .interval(getConfig().getNode("clean_old_locks_interval").getInt(40), TimeUnit.DAYS)
+                    .interval(getConfig().getNode("clean_old_locks_interval").getInt(2), TimeUnit.HOURS)
                     .execute(() -> {
 
-
+                        // TODO SQL Statement which deletes these old locks
 
                     })
                     .submit(getPluginContainer());

--- a/src/main/java/com/meronat/latch/Latch.java
+++ b/src/main/java/com/meronat/latch/Latch.java
@@ -31,6 +31,7 @@ import com.meronat.latch.bstats.Metrics;
 import com.meronat.latch.commands.AddAccessorCommand;
 import com.meronat.latch.commands.AdminBypassCommand;
 import com.meronat.latch.commands.ChangeLockCommand;
+import com.meronat.latch.commands.CleanCommand;
 import com.meronat.latch.commands.CreateDonationLockCommand;
 import com.meronat.latch.commands.CreatePasswordLockCommand;
 import com.meronat.latch.commands.CreatePrivateLockCommand;
@@ -61,6 +62,7 @@ import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.event.EventManager;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameInitializationEvent;
+import org.spongepowered.api.event.game.state.GamePostInitializationEvent;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
 import org.spongepowered.api.scheduler.Task;
@@ -135,13 +137,14 @@ public class Latch {
                 .child(new DisplayLockCommand().getCommand(), "info", "display")
                 .child(new UnlockCommand().getCommand(), "open", "unlock")
                 .child(new ListCommand().getCommand(), "list", "displayall")
-                .child(new HelpCommand().getCommand(), "help")
+                .child(new HelpCommand().getCommand(), "help", "?")
                 .child(new AddAccessorCommand().getCommand(), "add", "plus")
                 .child(new RemoveAccessorCommand().getCommand(), "remove", "minus", "rem", "removeplayer")
                 .child(new AdminBypassCommand().getCommand(), "bypass", "adminbypass", "admin")
                 .child(new PurgeCommand().getCommand(), "purge", "destroyall")
                 .child(new InfoCommand().getCommand(), "version", "authors")
                 .child(new LimitsCommand().getCommand(), "limits", "max")
+                .child(new CleanCommand().getCommand(), "clean", "misterclean")
                 .executor(new HelpCommand())
                 .build(), "latch", "lock");
 
@@ -155,16 +158,21 @@ public class Latch {
         }
     }
 
+    @Listener
+    public void onGamePostInitialization(GamePostInitializationEvent event) {
+        registerTasks();
+    }
+
     private void registerTasks() {
 
         if (getConfig().getNode("clean_old_locks").getBoolean(false)) {
             Task.builder()
                     .name("clean-old-locks")
-                    .interval(getConfig().getNode("clean_old_locks_interval").getInt(2), TimeUnit.HOURS)
+                    .async()
+                    .interval(getConfig().getNode("clean_old_locks_interval").getInt(4), TimeUnit.HOURS)
                     .execute(() -> {
-
-                        // TODO SQL Statement which deletes these old locks
-
+                        int daysOld = getConfig().getNode("clean_locks_older_than").getInt(40);
+                        getLogger().info("Successfully deleted " + storageHandler.clearLocksOlderThan(getConfig().getNode("clean_locks_older_than").getInt(daysOld)) + " locks older than " + daysOld + " days old.");
                     })
                     .submit(getPluginContainer());
         }

--- a/src/main/java/com/meronat/latch/Latch.java
+++ b/src/main/java/com/meronat/latch/Latch.java
@@ -63,6 +63,7 @@ import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GameInitializationEvent;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.scheduler.Task;
 import org.spongepowered.api.service.permission.PermissionService;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.Tristate;
@@ -72,6 +73,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @Plugin(
         id = Info.ID,
@@ -151,6 +153,22 @@ public class Latch {
                     p -> p.getUserSubjects().getDefaults().getSubjectData()
                             .setPermission(p.getDefaults().getActiveContexts(), "latch.normal", Tristate.TRUE));
         }
+    }
+
+    private void registerTasks() {
+
+        if (getConfig().getNode("clean_old_locks").getBoolean(false)) {
+            Task.builder()
+                    .name("clean-old-locks")
+                    .interval(getConfig().getNode("clean_old_locks_interval").getInt(40), TimeUnit.DAYS)
+                    .execute(() -> {
+
+
+
+                    })
+                    .submit(getPluginContainer());
+        }
+
     }
 
     private void registerListeners() {

--- a/src/main/java/com/meronat/latch/commands/CleanCommand.java
+++ b/src/main/java/com/meronat/latch/commands/CleanCommand.java
@@ -23,24 +23,7 @@
  * THE SOFTWARE.
  */
 
-package com.meronat.latch.listeners;
+package com.meronat.latch.commands;
 
-import com.meronat.latch.Latch;
-import org.spongepowered.api.Sponge;
-import org.spongepowered.api.entity.living.player.Player;
-import org.spongepowered.api.event.Listener;
-import org.spongepowered.api.event.filter.cause.Root;
-import org.spongepowered.api.event.network.ClientConnectionEvent;
-
-import java.time.LocalDateTime;
-
-public class PlayerDisconnectListener {
-
-    @Listener
-    public void onPlayerDisconnect(ClientConnectionEvent.Disconnect event, @Root Player player) {
-        Latch.getLockManager().removeBypassing(player.getUniqueId());
-        Sponge.getScheduler().createAsyncExecutor(Latch.getPluginContainer())
-                .execute(() -> Latch.getStorageHandler().updateLastAccessed(player.getUniqueId(), LocalDateTime.now()));
-    }
-
+public class CleanCommand {
 }

--- a/src/main/java/com/meronat/latch/entities/Lock.java
+++ b/src/main/java/com/meronat/latch/entities/Lock.java
@@ -173,7 +173,7 @@ public class Lock {
     }
 
     public String getPassword() {
-        return password;
+        return this.password;
     }
 
     public String getOwnerName() {
@@ -209,7 +209,7 @@ public class Lock {
     }
 
     public boolean getProtectFromRedstone() {
-        return protectFromRedstone;
+        return this.protectFromRedstone;
     }
 
     public LocalDateTime getLastAccessed() {
@@ -218,5 +218,6 @@ public class Lock {
 
     public void updateLastAccessed() {
         this.lastAccessed = LocalDateTime.now();
+        Sponge.getScheduler().createAsyncExecutor(Latch.getPluginContainer()).execute(() -> Latch.getLockManager().updateLockAttributes(this.owner, this.name, this));
     }
 }

--- a/src/main/java/com/meronat/latch/entities/Lock.java
+++ b/src/main/java/com/meronat/latch/entities/Lock.java
@@ -34,6 +34,7 @@ import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -58,11 +59,13 @@ public class Lock {
     private HashSet<UUID> ableToAccess;
     private boolean protectFromRedstone;
 
-    public Lock(UUID owner, LockType type, HashSet<Location<World>> location, String lockedObjectName, byte[] salt, String password, boolean protectFromRedstone) {
-        this(owner, LatchUtils.getRandomLockName(owner, lockedObjectName), type, location, lockedObjectName, salt, password, new HashSet<>(), protectFromRedstone);
+    private LocalDateTime lastAccessed;
+
+    public Lock(UUID owner, LockType type, HashSet<Location<World>> location, String lockedObjectName, byte[] salt, String password, boolean protectFromRedstone, LocalDateTime lastAccessed) {
+        this(owner, LatchUtils.getRandomLockName(owner, lockedObjectName), type, location, lockedObjectName, salt, password, new HashSet<>(), protectFromRedstone, lastAccessed);
     }
 
-    public Lock(UUID owner, String lockName, LockType type, HashSet<Location<World>> location, String lockedObjectName, byte[] salt, String password, HashSet<UUID> players, boolean protectFromRedstone) {
+    public Lock(UUID owner, String lockName, LockType type, HashSet<Location<World>> location, String lockedObjectName, byte[] salt, String password, HashSet<UUID> players, boolean protectFromRedstone, LocalDateTime lastAccessed) {
 
         this.owner = owner;
         this.type = type;
@@ -78,9 +81,11 @@ public class Lock {
         ableToAccess = players;
 
         this.protectFromRedstone = protectFromRedstone;
+
+        this.lastAccessed = lastAccessed;
     }
 
-    public Lock(UUID owner, LockType type, HashSet<Location<World>> location, String lockedObjectName, boolean protectFromRedstone) {
+    public Lock(UUID owner, LockType type, HashSet<Location<World>> location, String lockedObjectName, boolean protectFromRedstone, LocalDateTime lastAccessed) {
 
         this.owner = owner;
         this.name = LatchUtils.getRandomLockName(owner, lockedObjectName);
@@ -89,6 +94,7 @@ public class Lock {
         this.location = location;
         this.protectFromRedstone = protectFromRedstone;
         this.ableToAccess = new HashSet<>();
+        this.lastAccessed = lastAccessed;
 
     }
 
@@ -204,5 +210,13 @@ public class Lock {
 
     public boolean getProtectFromRedstone() {
         return protectFromRedstone;
+    }
+
+    public LocalDateTime getLastAccessed() {
+        return this.lastAccessed;
+    }
+
+    public void updateLastAccessed() {
+        this.lastAccessed = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/meronat/latch/interactions/CreateLockInteraction.java
+++ b/src/main/java/com/meronat/latch/interactions/CreateLockInteraction.java
@@ -39,6 +39,7 @@ import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.world.Location;
 import org.spongepowered.api.world.World;
 
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.UUID;
@@ -93,7 +94,7 @@ public class CreateLockInteraction implements LockInteraction {
             return false;
         }
 
-        Lock lock = new Lock(player.getUniqueId(), this.type, lockLocations, LatchUtils.getBlockNameFromType(blockState.getState().getType()), Latch.getLockManager().getProtectFromRedstone());
+        Lock lock = new Lock(player.getUniqueId(), this.type, lockLocations, LatchUtils.getBlockNameFromType(blockState.getState().getType()), Latch.getLockManager().getProtectFromRedstone(), LocalDateTime.now());
 
         if (this.type.equals(LockType.PASSWORD_ALWAYS) || this.type.equals(LockType.PASSWORD_ONCE)) {
 

--- a/src/main/java/com/meronat/latch/listeners/InteractBlockListener.java
+++ b/src/main/java/com/meronat/latch/listeners/InteractBlockListener.java
@@ -106,13 +106,14 @@ public class InteractBlockListener {
         } else {
             //Otherwise we only care if it's a lock
             if(Latch.getLockManager().isLockableBlock(event.getTargetBlock().getState().getType())) {
-                Optional<Lock> optionalLock = Latch.getLockManager().getLock(event.getTargetBlock().getLocation().get());
-
-                //If there's a lock (non-donation) that the player shouldn't be able to access
-                if(optionalLock.isPresent() && optionalLock.get().getLockType() != LockType.DONATION && !optionalLock.get().canAccess(player.getUniqueId()) ) {
-                    player.sendMessage(Text.of(TextColors.RED, "You cannot access this lock."));
-                    event.setCancelled(true);
-                }
+                Latch.getLockManager().getLock(event.getTargetBlock().getLocation().get()).ifPresent(lock -> {
+                    if (lock.getLockType() != LockType.DONATION && !lock.canAccess(player.getUniqueId())) {
+                        player.sendMessage(Text.of(TextColors.RED, "You cannot access this lock."));
+                        event.setCancelled(true);
+                    } else {
+                        lock.updateLastAccessed();
+                    }
+                });
             }
 
         }

--- a/src/main/java/com/meronat/latch/listeners/PlayerDisconnectListener.java
+++ b/src/main/java/com/meronat/latch/listeners/PlayerDisconnectListener.java
@@ -26,21 +26,16 @@
 package com.meronat.latch.listeners;
 
 import com.meronat.latch.Latch;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.filter.cause.Root;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
-
-import java.time.LocalDateTime;
 
 public class PlayerDisconnectListener {
 
     @Listener
     public void onPlayerDisconnect(ClientConnectionEvent.Disconnect event, @Root Player player) {
         Latch.getLockManager().removeBypassing(player.getUniqueId());
-        Sponge.getScheduler().createAsyncExecutor(Latch.getPluginContainer())
-                .execute(() -> Latch.getStorageHandler().updateLastAccessed(player.getUniqueId(), LocalDateTime.now()));
     }
 
 }

--- a/src/main/java/com/meronat/latch/storage/SqlHandler.java
+++ b/src/main/java/com/meronat/latch/storage/SqlHandler.java
@@ -35,9 +35,12 @@ import org.spongepowered.api.world.World;
 
 import java.io.File;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -72,6 +75,7 @@ public class SqlHandler {
                 "PASSWORD varchar(256) NOT NULL, " +
                 "SALT varchar(64) NOT NULL, " +
                 "REDSTONE_PROTECT BOOLEAN NOT NULL, " +
+                "ACCESSED DATETIME NOT NULL," +
                 "PRIMARY KEY(ID), CONSTRAINT UQ_OWNER_NAME UNIQUE (OWNER_UUID, LOCK_NAME) )";
 
         String createLocationTable = "CREATE TABLE IF NOT EXISTS LOCK_LOCATIONS (" +
@@ -101,6 +105,20 @@ public class SqlHandler {
             getLogger().error("Error running SQL createTables:");
             e.printStackTrace();
         }
+
+        try (
+                Connection connection = getConnection();
+                PreparedStatement add = connection.prepareStatement("ALTER TABLE LOCK ADD COLUMN ACCESSED DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP");
+        ) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            if (!metaData.getColumns(null, null, "LOCK", "ACCESSED").next()) {
+                add.execute();
+            }
+        } catch (SQLException e) {
+            getLogger().error("There was a problem adding the ACCESSED column. Please report this to the developers:");
+            e.printStackTrace();
+        }
+
     }
 
     public Optional<Lock> getLockByLocation(Location location) {
@@ -109,7 +127,7 @@ public class SqlHandler {
         try (
                 Connection connection = getConnection();
                 PreparedStatement ps = connection.prepareStatement(
-                        "SELECT ID, OWNER_UUID, LOCK_NAME, LOCK_TYPE, LOCKED_OBJECT, SALT, PASSWORD, REDSTONE_PROTECT FROM LOCK_LOCATIONS JOIN LOCK ON (LOCK_LOCATIONS.LOCK_ID = LOCK.ID) "
+                        "SELECT ID, OWNER_UUID, LOCK_NAME, LOCK_TYPE, LOCKED_OBJECT, SALT, PASSWORD, REDSTONE_PROTECT, ACCESSED FROM LOCK_LOCATIONS JOIN LOCK ON (LOCK_LOCATIONS.LOCK_ID = LOCK.ID) "
                                 + "WHERE LOCK_LOCATIONS.WORLD_UUID = ? AND LOCK_LOCATIONS.X = ? AND LOCK_LOCATIONS.Y = ? AND LOCK_LOCATIONS.Z = ?")
         ) {
             ps.setObject(1, location.getExtent().getUniqueId());
@@ -131,7 +149,8 @@ public class SqlHandler {
                             tempLock.getBytes("SALT"),
                             tempLock.getString("PASSWORD"),
                             getAbleToAccessByID(tempLock.getInt("ID")),
-                            tempLock.getBoolean("REDSTONE_PROTECT")));
+                            tempLock.getBoolean("REDSTONE_PROTECT"),
+                            tempLock.getTimestamp("ACCESSED").toLocalDateTime()));
                 }
             }
 
@@ -267,7 +286,7 @@ public class SqlHandler {
         try (
                 Connection connection = getConnection();
                 PreparedStatement psLock = connection.prepareStatement(
-                        "INSERT INTO LOCK(OWNER_UUID, LOCK_NAME, LOCK_TYPE, LOCKED_OBJECT, SALT, PASSWORD, REDSTONE_PROTECT) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                        "INSERT INTO LOCK(OWNER_UUID, LOCK_NAME, LOCK_TYPE, LOCKED_OBJECT, SALT, PASSWORD, REDSTONE_PROTECT, ACCESSED) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                         PreparedStatement.RETURN_GENERATED_KEYS);
                 PreparedStatement psLocations = connection.prepareStatement("INSERT INTO LOCK_LOCATIONS(LOCK_ID, WORLD_UUID, X, Y, Z) VALUES (?, ?, ?, ?, ?)");
                 PreparedStatement psPlayers = connection.prepareStatement("INSERT INTO LOCK_PLAYERS(LOCK_ID, PLAYER_UUID) VALUES (?, ?)");
@@ -279,6 +298,7 @@ public class SqlHandler {
             psLock.setBytes(5, lock.getSalt());
             psLock.setString(6, lock.getPassword());
             psLock.setBoolean(7, lock.getProtectFromRedstone());
+            psLock.setTimestamp(8, Timestamp.valueOf(lock.getLastAccessed()));
 
             psLock.executeUpdate();
 
@@ -503,7 +523,7 @@ public class SqlHandler {
         try (
                 Connection connection = getConnection();
                 PreparedStatement ps = connection.prepareStatement(
-                        "UPDATE LOCK SET OWNER_UUID = ?, LOCK_NAME = ?, LOCK_TYPE = ?, PASSWORD = ?, SALT = ?, REDSTONE_PROTECT = ? WHERE OWNER_UUID = ? AND LOCK_NAME = ?");
+                        "UPDATE LOCK SET OWNER_UUID = ?, LOCK_NAME = ?, LOCK_TYPE = ?, PASSWORD = ?, SALT = ?, REDSTONE_PROTECT = ?, ACCESSED = ? WHERE OWNER_UUID = ? AND LOCK_NAME = ?");
         ) {
             ps.setString(1, thisLock.getOwner().toString());
             ps.setString(2, thisLock.getName());
@@ -511,8 +531,9 @@ public class SqlHandler {
             ps.setString(4, thisLock.getPassword());
             ps.setBytes(5, thisLock.getSalt());
             ps.setBoolean(6, thisLock.getProtectFromRedstone());
-            ps.setString(7, originalOwner.toString());
-            ps.setString(8, originalName);
+            ps.setTimestamp(7, Timestamp.valueOf(thisLock.getLastAccessed()));
+            ps.setString(8, originalOwner.toString());
+            ps.setString(9, originalName);
 
             ps.executeUpdate();
         } catch (SQLException e) {
@@ -544,7 +565,7 @@ public class SqlHandler {
         try (
                 Connection connection = getConnection();
                 PreparedStatement ps = connection.prepareStatement(
-                        "SELECT ID, OWNER_UUID, LOCK_NAME, LOCK_TYPE, LOCKED_OBJECT, SALT, PASSWORD, REDSTONE_PROTECT FROM LOCK WHERE OWNER_UUID = ?");
+                        "SELECT ID, OWNER_UUID, LOCK_NAME, LOCK_TYPE, LOCKED_OBJECT, SALT, PASSWORD, REDSTONE_PROTECT, ACCESSED FROM LOCK WHERE OWNER_UUID = ?");
         ) {
             ps.setString(1, uniqueId.toString());
 
@@ -561,7 +582,8 @@ public class SqlHandler {
                             rs.getBytes("SALT"),
                             rs.getString("PASSWORD"),
                             getAbleToAccessByID(rs.getInt("ID")),
-                            rs.getBoolean("REDSTONE_PROTECT")));
+                            rs.getBoolean("REDSTONE_PROTECT"),
+                            rs.getTimestamp("ACCESSED").toLocalDateTime()));
                 }
             }
         } catch (SQLException e) {
@@ -602,4 +624,15 @@ public class SqlHandler {
         //Sql exception, prevent placement
         return true;
     }
+
+    public void updateLastAccessed(UUID player, LocalDateTime now) {
+        try (PreparedStatement ps = getConnection().prepareStatement("UPDATE LOCK SET ACCESSED = ? WHERE OWNER_UUID = ?")) {
+            ps.setTimestamp(1, Timestamp.valueOf(now));
+            ps.setString(2, player.toString());
+        } catch (SQLException e) {
+            getLogger().error("Error updateLastAccessed: " + player);
+            e.printStackTrace();
+        }
+    }
+
 }

--- a/src/main/java/com/meronat/latch/storage/SqlHandler.java
+++ b/src/main/java/com/meronat/latch/storage/SqlHandler.java
@@ -665,12 +665,9 @@ public class SqlHandler {
                     }
                 }
             }
-
         } catch (SQLException e) {
-
             getLogger().error("Error clearLocksOlderThan: " + days);
             e.printStackTrace();
-
         }
 
         return amountDeleted;


### PR DESCRIPTION
This will be useful as administrators can see when a lock was last accessed as well as whoever else if they are curious. Also we will use it so administrators can delete all locks which have not been accessed in a specified amount of time. They can either force it with a clean command or enable a scheduled task. I still have some work to do and I'll hopefully get to it in the next few days.

- [x] Create SQL statement to delete all locks which are older than X days
- [x] Create clean command which allows an admin to force delete locks older than X days
- [ ] Add last accessed information to lock display